### PR TITLE
jenkins_builder: netstat is used by some regression tests

### DIFF
--- a/roles/jenkins_builder/tasks/pkgs.yml
+++ b/roles/jenkins_builder/tasks/pkgs.yml
@@ -12,6 +12,7 @@
   with_items:
   # needed for some tests
   - net-tools
+  - netstat
   # used for smoke.sh, for killall
   - psmisc
   - libacl-devel


### PR DESCRIPTION
We have one test-case that uses netstat (tests/bugs/fuse/bug-924726.t).  When
netstat is not installed, this testcase will not be run correctly.

Signed-off-by: Niels de Vos <ndevos@redhat.com>