### PR TITLE
Add a role for bugs.cloud.gluster.org

### DIFF
--- a/roles/nginx_bugs/README.md
+++ b/roles/nginx_bugs/README.md
@@ -1,0 +1,2 @@
+Role to deploy bugs.gluster.org web application, who simply download
+by cron the list of bugs and update a static file to summazrize them.

--- a/roles/nginx_bugs/defaults/main.yml
+++ b/roles/nginx_bugs/defaults/main.yml
@@ -1,0 +1,1 @@
+bugs_username: _bugs_updater

--- a/roles/nginx_bugs/meta/main.yml
+++ b/roles/nginx_bugs/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+- { role: nginx }

--- a/roles/nginx_bugs/tasks/main.yml
+++ b/roles/nginx_bugs/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Make sure required packages are present
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items:
+  - python-bugzilla
+  - git
+  - python-requests
+
+- name: Install web configuration
+  template:
+    dest: "/etc/nginx/conf.d/{{ server_name }}.conf"
+    src: nginx.conf
+  notify: restart nginx
+
+- name: Create {{ bugs_username }} to build
+  user:
+    name: "{{ bugs_username }}"
+    comment: "{{ server_name }} builder user"
+    home: "/srv/{{ server_name }}/html/"
+
+- name: Fix the selinux context
+  command: semanage fcontext -a -t httpd_user_rw_content_t /srv/{{ server_name }}/html/(/.*)?
+
+- name: Create the directory holding git checkout
+  file:
+    name: "/srv/{{ server_name }}/html/"
+    state: directory
+
+- name: Clone the repo
+  git:
+    repo: https://github.com/gluster/gluster-bugs-webui.git
+    dest: "/srv/{{ server_name }}/html/"
+  become: yes
+  become_user: "{{ bugs_username }}"
+  become_method: 'su'
+
+- name: Setup a cronjob every hour
+  cron:
+    minutes: 0
+    job: "/srv/{{ server_name }}/html/run-report.sh"
+    user: "{{ bugs_username }}"
+
+- name: Upgrade the code every day
+  cron:
+    minutes: 0
+    hour: 2
+    user: "{{ bugs_username }}"
+    job: "cd /srv/{{ server_name }}/html/ && git pull --rebase"

--- a/roles/nginx_bugs/templates/nginx.conf
+++ b/roles/nginx_bugs/templates/nginx.conf
@@ -1,0 +1,9 @@
+server {
+        listen      80;
+        server_name {{ server_name }};
+
+        location / {
+                root /srv/{{ server_name }}/html;
+                index gluster-bugs.html;
+        }
+}

--- a/roles/nginx_bugs/vars/main.yml
+++ b/roles/nginx_bugs/vars/main.yml
@@ -1,0 +1,1 @@
+server_name: "bugs.cloud.gluster.org"


### PR DESCRIPTION
So I am trying to see if we can move bugs.cloud.gluster to ansible. For now, that's a draft and would like people to review it, it is still missing a few stuff and currently run as root, which annoy me a bit. It also miss the cronjob in ndevos home that I need to port over.

So please do not merge for now :)
(also, i am out for 2 days, so there is no urgency, that's more a exploration on how we can handle PR and contribution, and so I tried to do that on github for that one )

Ping @nixpanic and @nigelbabu  
