### PR TITLE
Add python-docopt to the rht builders

### DIFF
--- a/roles/jenkins_builder/tasks/pkgs.yml
+++ b/roles/jenkins_builder/tasks/pkgs.yml
@@ -25,6 +25,7 @@
   - cppcheck
   - clang
   - clang-analyzer
+  - python-docopt
   when: '"jenkins_builders_rht" in group_names and ansible_distribution == "CentOS"'
 
 - package:


### PR DESCRIPTION
This is needed for the remote Glusto trigger. Can be removed when we run
glusto in our own hardware.