### PR TITLE
Add libselinux-python package on jenkins nodes

### DIFF
--- a/roles/jenkins_builder/tasks/pkgs.yml
+++ b/roles/jenkins_builder/tasks/pkgs.yml
@@ -83,6 +83,8 @@
     - mercurial
     - bzr
     - golang
+    # for running ansible file modules on builders
+    - libselinux-python
   when: ansible_system == 'Linux'
 
 - name: Install jenkins builder Fedora packages


### PR DESCRIPTION
Ansible requires libselinux-python package to be installed on
hosts where Ansible is running file modules in case SELinux is
enabled. It is needed while creating machines using Ansible for
running distributed regression framework.

Signed-off-by: Deepshikha Khandelwal <dkhandel@redhat.com>