### PR TITLE
Add playbook to setup the basic instance of gluster

### DIFF
--- a/playbooks/deploy_gluster_basic_instance.yml
+++ b/playbooks/deploy_gluster_basic_instance.yml
@@ -1,0 +1,4 @@
+- hosts: image_builder
+  include_role:
+    name: jenkins_builder
+    tasks_from: basic_instance.yml

--- a/roles/jenkins_builder/tasks/basic_instance.yml
+++ b/roles/jenkins_builder/tasks/basic_instance.yml
@@ -1,0 +1,10 @@
+---
+- include: pkgs.yml
+
+- include: authroot_georep.yml
+
+- include: disable_ipv6_linux.yml
+  when: ansible_system == 'Linux'
+
+- include: setup_rackspace_network.yml
+  when: ansible_system == 'Linux' and (location == 'rackspace' or location == 'rax')


### PR DESCRIPTION
Add playbook to setup the basic instance of gluster which includes the tasks from jenkins_builder role to install packages and do network configurations. It will be used in re-building the image for distributed regression testing.

Signed-off-by: Deepshikha Khandelwal <dkhandel@redhat.com>